### PR TITLE
Replace deprecated drawAtPoint:withFont: method

### DIFF
--- a/Classes/AMRatingControl.m
+++ b/Classes/AMRatingControl.m
@@ -146,7 +146,9 @@ static const NSString *kDefaultSolidChar = @"★";
 		else
         {
             CGContextSetFillColorWithColor(UIGraphicsGetCurrentContext(), _solidColor.CGColor);
-            [kDefaultSolidChar drawAtPoint:currPoint withFont:[UIFont boldSystemFontOfSize:_starFontSize]];
+            [kDefaultSolidChar drawAtPoint:currPoint
+                            withAttributes:@{NSFontAttributeName: [UIFont boldSystemFontOfSize:_starFontSize],
+                                             NSForegroundColorAttributeName: _solidColor}];
         }
         
 		currPoint.x += (_starSize.width + _starSpacing);
@@ -163,7 +165,9 @@ static const NSString *kDefaultSolidChar = @"★";
 		else
         {
             CGContextSetFillColorWithColor(UIGraphicsGetCurrentContext(), _emptyColor.CGColor);
-			[kDefaultEmptyChar drawAtPoint:currPoint withFont:[UIFont boldSystemFontOfSize:_starFontSize]];
+            [kDefaultEmptyChar drawAtPoint:currPoint
+                            withAttributes:@{NSFontAttributeName: [UIFont boldSystemFontOfSize:_starFontSize],
+                                             NSForegroundColorAttributeName: _emptyColor}];
         }
 		currPoint.x += (_starSize.width + _starSpacing);
 	}


### PR DESCRIPTION
Method is deprecated since iOS 7.0 and is replaced with
drawAtPoint:withAttributes:
